### PR TITLE
Fix Crash when running in versions lower than VS2017v141

### DIFF
--- a/include/matador/sql/basic_dialect.hpp
+++ b/include/matador/sql/basic_dialect.hpp
@@ -31,7 +31,7 @@ struct build_info
   build_info(const sql &s, basic_dialect *d);
 
   build_info(const build_info&) = default;
-  build_info(build_info&&) noexcept = default;
+  build_info(build_info&&) = default;
   build_info& operator=(const build_info&) = default;
   build_info& operator=(build_info&&) = default;
 

--- a/src/sql/connection_info.cpp
+++ b/src/sql/connection_info.cpp
@@ -5,8 +5,8 @@
 namespace matador {
 
 connection_info connection_info::parse(const std::string &info, unsigned short default_port, const std::string &default_driver) {
-  static const std::regex DNS_RGX (R"((\w+):\/\/((([\w]+)(:([\w!]+))?)@)?((((([\w.\(\)\\]+)([:]([\d]+))?)?)\/)?(([\w.]+)( \((.*)\))?)))");
-
+  //static const std::regex DNS_RGX (R"((\w+):\/\/((([\w]+)(:([\w!]+))?)@)?((((([\w.\(\)\\]+)([:]([\d]+))?)?)\/)?(([\w.]+)( \((.*)\))?)))");
+  static const std::regex DNS_RGX(R"((\w+):\/\/((([\w]+)(:([^@]+))?)@)?((((([\w.\(\)\\]+)(:(\d+))?)?)\/)?(([^ \(\)]+)( \((.*)\))?)))");
   std::smatch what;
 
   if (!std::regex_match(info, what, DNS_RGX)) {


### PR DESCRIPTION
Fix Crash when running in versions lower than VS2017v141